### PR TITLE
Removed unnecessary auth from dockerrun.aws.json

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -4,10 +4,6 @@
     "Name": "uppoints/docker-nexus-jar-runner",
     "Update": "true"
   },
-  "Authentication": {
-    "Bucket": "uppoints-configs",
-    "Key": "dockercfg"
-  },
   "Ports": [
     {
       "ContainerPort": "8080"


### PR DESCRIPTION
Image is public, therefore no authentication should be necessary
